### PR TITLE
fixed version to graphql-clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [ring/ring-defaults "0.2.1"]
                  [ring/ring-json "0.4.0"]
                  [ring-cors "0.1.8"]
-                 [graphql-clj "0.2.4-SNAPSHOT"]]
+                 [graphql-clj "0.2.5"]]
   :main ^:skip-aot graphql-clj-starter.core
   :target-path "target/%s"
   :resource-paths ["build"]


### PR DESCRIPTION
It was not finding this version.

<img width="756" alt="screen shot 2017-11-01 at 23 00 39" src="https://user-images.githubusercontent.com/6734111/32304872-56a94b30-bf59-11e7-832b-96007f2ac4e4.png">
